### PR TITLE
테스트용: H2, 인메모리 DB

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,6 +7,8 @@ logging:
 
 spring:
   application.name : test-data
+  datasource:
+    url: jdbc:h2:mem:testdb
   jpa:
     open-in-view: false
     defer-datasource-initialization: true
@@ -15,3 +17,11 @@ spring:
     properties:
       hibernate.format_sql: true
   sql.init.mode: always
+
+
+---
+
+spring:
+  config.activate.on-profile: test
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DATABASE_TO_LOWER=TRUE

--- a/src/test/java/arile/toy/test_data/domain/constant/JpaTest.java
+++ b/src/test/java/arile/toy/test_data/domain/constant/JpaTest.java
@@ -1,0 +1,15 @@
+package arile.toy.test_data.domain.constant;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest
+public class JpaTest {
+
+    @Test
+    void test(){
+        System.out.println("JpaTest");
+    }
+}


### PR DESCRIPTION
이 작업은 H2 DB를 사용하도록 스프링 부트 프로퍼티를 추가한다.
또한 테스트 프로파일을 별도 마련하여 mysql 호환성 모드로도 h2를 동작시킬 수 있도록 환경을 준비한다.'

This closes #17.